### PR TITLE
Fix credentials usage in frontend

### DIFF
--- a/frontend
+++ b/frontend
@@ -51,7 +51,7 @@ export default function App() {
     try {
       await fetch("/api/auth/logout", {
         method: "POST",
-        credentials: "include"(888***)
+        credentials: "include"
       });
       setIsAuthenticated(false);
       setUser(null);


### PR DESCRIPTION
## Summary
- clean up `credentials` option in logout fetch call

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(fails: command not found)*