### PR TITLE
Add express server skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # Demo
+
+This repository contains a small example Node.js application for generating episodic content.
+
+## Running the server
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the server:
+   ```bash
+   node server.js
+   ```
+   The server uses the configuration defined in `config.js` and listens on the port specified there (default `3000`).
+
+## Project structure
+
+- `server.js` &ndash; Express application that configures Passport, session middleware and mounts the API routes.
+- `config.js` &ndash; Application configuration loaded by the server.
+- `routes/authRoutes.js` &ndash; Google OAuth authentication endpoints.
+- `routes/googleDocsRoutes.js` &ndash; Endpoints for importing content from Google Docs.
+- `services/` &ndash; Helper services used by the routes.
+
+The server also serves static files from the `public` directory if it exists, making it possible to host a frontend alongside the API routes.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,52 @@
+// config.js - Configuration file for the application
+
+// This file would be loaded when the application starts
+// In production, these values should be set in environment variables
+
+module.exports = {
+  // Server configuration
+  port: process.env.PORT || 3000,
+  nodeEnv: process.env.NODE_ENV || 'development',
+
+  // Session configuration
+  session: {
+    secret: process.env.SESSION_SECRET || 'your-secret-key-for-development-only',
+    cookie: {
+      maxAge: 24 * 60 * 60 * 1000, // 24 hours
+    }
+  },
+
+  // Google OAuth configuration
+  google: {
+    clientId: process.env.GOOGLE_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/api/auth/google/callback',
+  },
+
+  // Google Gemini AI configuration
+  gemini: {
+    apiKey: process.env.GOOGLE_GEMINI_API_KEY,
+    maxTokens: 8192,
+    temperature: 0.7,
+    topP: 0.9,
+    apiEndpoint: 'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent',
+  },
+
+  // Rate limiting to prevent abuse
+  rateLimit: {
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100 // limit each IP to 100 requests per windowMs
+  },
+
+  // Maximum allowed values
+  limits: {
+    maxSynopsisWords: 2000,
+    maxEpisodes: 200,
+    validWordCounts: [1000, 2000, 3000, 4000, 5000]
+  },
+
+  // Allowed origins for CORS
+  corsOrigins: process.env.NODE_ENV === 'production'
+    ? ['https://yourdomain.com']
+    : ['http://localhost:3000']
+};

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,0 +1,64 @@
+// routes/authRoutes.js - Authentication routes
+const express = require('express');
+const passport = require('passport');
+const router = express.Router();
+
+/**
+ * @route GET /api/auth/google
+ * @desc Authenticate with Google OAuth
+ * @access Public
+ */
+router.get('/google',
+  passport.authenticate('google', { 
+    scope: [
+      'profile', 
+      'email', 
+      'https://www.googleapis.com/auth/documents.readonly'
+    ] 
+  })
+);
+
+/**
+ * @route GET /api/auth/google/callback
+ * @desc Google OAuth callback
+ * @access Public
+ */
+router.get('/google/callback', 
+  passport.authenticate('google', { failureRedirect: '/' }),
+  (req, res) => {
+    res.redirect('/');
+  }
+);
+
+/**
+ * @route POST /api/auth/logout
+ * @desc Logout user
+ * @access Public
+ */
+router.post('/logout', (req, res) => {
+  req.logout((err) => {
+    if (err) {
+      return res.status(500).json({ error: "Error during logout" });
+    }
+    res.json({ success: true });
+  });
+});
+
+/**
+ * @route GET /api/auth/status
+ * @desc Get authentication status
+ * @access Public
+ */
+router.get('/status', (req, res) => {
+  res.json({
+    isAuthenticated: req.isAuthenticated(),
+    user: req.user ? {
+      id: req.user.id,
+      name: req.user.name,
+      email: req.user.email,
+      profilePicture: req.user.profilePicture
+    } : null
+  });
+});
+
+module.exports = router;

--- a/routes/googleDocsRoutes.js
+++ b/routes/googleDocsRoutes.js
@@ -1,0 +1,62 @@
+// routes/googleDocsRoutes.js - Google Docs integration routes
+const express = require('express');
+const router = express.Router();
+const GoogleService = require('../services/googleService');
+
+// Authentication middleware
+const isAuthenticated = (req, res, next) => {
+  if (req.isAuthenticated()) {
+    return next();
+  }
+  res.status(401).json({ error: "Not authenticated" });
+};
+
+/**
+ * @route GET /api/google-docs/import
+ * @desc Import document from Google Docs
+ * @access Private
+ */
+router.get('/import', isAuthenticated, async (req, res) => {
+  const { docId } = req.query;
+  
+  if (!docId) {
+    return res.status(400).json({ error: "Document ID is required" });
+  }
+  
+  try {
+    // Initialize Google service with user's access token
+    const googleService = new GoogleService(req.user.accessToken, req.user.refreshToken);
+    
+    // Import document content
+    const content = await googleService.importDocument(docId);
+    
+    return res.json({ content });
+    
+  } catch (error) {
+    console.error('Error importing from Google Docs:', error);
+    return res.status(500).json({ error: `Failed to import document: ${error.message}` });
+  }
+});
+
+/**
+ * @route GET /api/google-docs/list
+ * @desc List user's Google Docs
+ * @access Private
+ */
+router.get('/list', isAuthenticated, async (req, res) => {
+  try {
+    // Initialize Google service with user's access token
+    const googleService = new GoogleService(req.user.accessToken, req.user.refreshToken);
+    
+    // Get list of documents
+    const documents = await googleService.listDocuments();
+    
+    return res.json({ documents });
+    
+  } catch (error) {
+    console.error('Error listing Google Docs:', error);
+    return res.status(500).json({ error: `Failed to list documents: ${error.message}` });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const session = require('express-session');
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const path = require('path');
+
+const config = require('./config');
+
+const authRoutes = require('./routes/authRoutes');
+const googleDocsRoutes = require('./routes/googleDocsRoutes');
+
+const app = express();
+
+// Basic serialization for session support
+passport.serializeUser((user, done) => {
+  done(null, user);
+});
+
+passport.deserializeUser((obj, done) => {
+  done(null, obj);
+});
+
+// Configure Google OAuth strategy
+passport.use(new GoogleStrategy({
+  clientID: config.google.clientId,
+  clientSecret: config.google.clientSecret,
+  callbackURL: config.google.callbackUrl
+}, (accessToken, refreshToken, profile, done) => {
+  // Build a minimal user object to store in the session
+  const user = {
+    id: profile.id,
+    name: profile.displayName,
+    email: profile.emails && profile.emails[0] ? profile.emails[0].value : null,
+    profilePicture: profile.photos && profile.photos[0] ? profile.photos[0].value : null,
+    accessToken,
+    refreshToken
+  };
+  done(null, user);
+}));
+
+// Session middleware
+app.use(session({
+  secret: config.session.secret,
+  resave: false,
+  saveUninitialized: false,
+  cookie: config.session.cookie
+}));
+
+app.use(passport.initialize());
+app.use(passport.session());
+
+app.use(express.json());
+
+// Mount API routes
+app.use('/api/auth', authRoutes);
+app.use('/api/google-docs', googleDocsRoutes);
+
+// Serve frontend assets if available
+const publicDir = path.join(__dirname, 'public');
+app.use(express.static(publicDir));
+
+// Fallback to index.html for SPA
+app.get('*', (req, res) => {
+  const indexPath = path.join(publicDir, 'index.html');
+  res.sendFile(indexPath);
+});
+
+const PORT = config.port;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/services/episodeGenerator.js
+++ b/services/episodeGenerator.js
@@ -1,0 +1,122 @@
+// episodeGenerator.js - Service for generating episodic content
+const axios = require('axios');
+const config = require('./config');
+
+/**
+ * Class to handle episode generation using Google Gemini API
+ */
+class EpisodeGenerator {
+  /**
+   * Initialize the episode generator
+   * @param {string} apiKey - Google Gemini API key
+   */
+  constructor(apiKey = config.gemini.apiKey) {
+    this.apiKey = apiKey;
+    this.apiEndpoint = config.gemini.apiEndpoint;
+  }
+  
+  /**
+   * Generate a single episode using Google Gemini
+   * @param {object} params - Parameters for episode generation
+   * @param {string} params.synopsis - The story synopsis
+   * @param {string} params.genre - The genre of the story
+   * @param {string} params.timeline - The timeline/era of the story
+   * @param {number} params.episodeNumber - Current episode number
+   * @param {number} params.totalEpisodes - Total number of episodes
+   * @param {number} params.wordCount - Target word count for the episode
+   * @returns {Promise<object>} - Generated episode content
+   */
+  async generateEpisode(params) {
+    const { synopsis, genre, timeline, episodeNumber, totalEpisodes, wordCount } = params;
+    
+    // Create prompt for Google Gemini
+    const prompt = `
+      You are an expert writer who specializes in creating episodic content.
+      
+      CONTEXT:
+      - Genre: ${genre}
+      - Era/Timeline: ${timeline}
+      - Word Count Target: ${wordCount} words
+      - Episode Number: ${episodeNumber} of ${totalEpisodes}
+      
+      STORY SYNOPSIS:
+      ${synopsis}
+      
+      TASK:
+      Create an engaging Episode ${episodeNumber} based on the synopsis above. The episode should:
+      1. Match the specified genre (${genre}) and timeline/era (${timeline})
+      2. Use language, terminology, and style appropriate for the era
+      3. Be approximately ${wordCount} words in length
+      4. Have a clear beginning, middle, and end while fitting into a larger story arc
+      5. Include character development and dialogue where appropriate
+      6. End with a hook that entices readers to continue to the next episode
+      
+      FORMAT YOUR RESPONSE AS A SINGLE CONTINUOUS NARRATIVE WITHOUT HEADERS OR SECTIONS.
+    `;
+    
+    try {
+      // Call Google Gemini API
+      const response = await axios.post(
+        `${this.apiEndpoint}?key=${this.apiKey}`,
+        {
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: {
+            temperature: config.gemini.temperature,
+            maxOutputTokens: config.gemini.maxTokens,
+            topP: config.gemini.topP,
+          }
+        }
+      );
+      
+      // Process response
+      const content = response.data.candidates[0].content.parts[0].text;
+      
+      return {
+        episodeNumber,
+        content,
+        wordCount: content.split(/\s+/).length
+      };
+    } catch (error) {
+      console.error('Error calling Gemini API:', error);
+      throw new Error(`Failed to generate episode content: ${error.message}`);
+    }
+  }
+  
+  /**
+   * Generate multiple episodes
+   * @param {object} params - Parameters for episode generation
+   * @param {string} params.synopsis - The story synopsis
+   * @param {string} params.genre - The genre of the story
+   * @param {string} params.timeline - The timeline/era of the story
+   * @param {number} params.episodeCount - Number of episodes to generate
+   * @param {number} params.wordCount - Target word count for each episode
+   * @returns {Promise<Array>} - Array of generated episodes
+   */
+  async generateEpisodes(params) {
+    const { synopsis, genre, timeline, episodeCount, wordCount } = params;
+    const episodes = [];
+    
+    // Generate episodes sequentially to prevent rate limiting
+    for (let i = 0; i < episodeCount; i++) {
+      const episode = await this.generateEpisode({
+        synopsis,
+        genre,
+        timeline,
+        episodeNumber: i + 1,
+        totalEpisodes: episodeCount,
+        wordCount
+      });
+      
+      episodes.push(episode);
+      
+      // Add a small delay to prevent hitting rate limits
+      if (i < episodeCount - 1) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    
+    return episodes;
+  }
+}
+
+module.exports = EpisodeGenerator;

--- a/services/googleService.js
+++ b/services/googleService.js
@@ -1,0 +1,86 @@
+// googleService.js - Service for Google API integration
+const { google } = require('googleapis');
+
+/**
+ * Class to handle Google API interactions
+ */
+class GoogleService {
+  /**
+   * Initialize the Google service with user credentials
+   * @param {string} accessToken - User's Google access token
+   * @param {string} refreshToken - User's Google refresh token (optional)
+   */
+  constructor(accessToken, refreshToken = null) {
+    this.auth = new google.auth.OAuth2();
+    this.auth.setCredentials({ 
+      access_token: accessToken,
+      refresh_token: refreshToken
+    });
+    
+    this.docs = google.docs({ version: 'v1', auth: this.auth });
+  }
+  
+  /**
+   * Import document content from Google Docs
+   * @param {string} documentId - Google Docs document ID
+   * @returns {Promise<string>} - Document content as plain text
+   */
+  async importDocument(documentId) {
+    try {
+      // Get the document
+      const { data } = await this.docs.documents.get({
+        documentId: documentId
+      });
+      
+      // Extract text content from document
+      let content = '';
+      const { body } = data;
+      
+      if (body && body.content) {
+        content = body.content
+          .filter(item => item.paragraph) // Only get paragraph elements
+          .map(item => {
+            const paragraph = item.paragraph;
+            if (paragraph.elements) {
+              return paragraph.elements
+                .map(element => element.textRun ? element.textRun.content : '')
+                .join('');
+            }
+            return '';
+          })
+          .join('')
+          .trim();
+      }
+      
+      return content;
+    } catch (error) {
+      console.error('Error importing document from Google Docs:', error);
+      throw new Error(`Failed to import document: ${error.message}`);
+    }
+  }
+  
+  /**
+   * Get list of documents from user's Google Drive
+   * Will be used for future enhancement
+   * @returns {Promise<Array>} - List of user's documents
+   */
+  async listDocuments() {
+    try {
+      const drive = google.drive({ version: 'v3', auth: this.auth });
+      
+      const response = await drive.files.list({
+        q: "mimeType='application/vnd.google-apps.document'",
+        fields: 'files(id, name)',
+        spaces: 'drive',
+        pageSize: 50
+      });
+      
+      return response.data.files;
+    } catch (error) {
+      console.error('Error listing documents from Google Drive:', error);
+      throw new Error(`Failed to list documents: ${error.message}`);
+    }
+  }
+}
+
+module.exports = GoogleService;


### PR DESCRIPTION
## Summary
- add `server.js` with Express, session and Passport setup
- port old snippets into real config, route and service files
- document how to run the server in README

## Testing
- `npm test` *(fails: Could not read package.json)*